### PR TITLE
Prevent `NSInvalidArgumentException` in `auditAllViewControllerLeaks`

### DIFF
--- a/UIViewController+TJLeakDetection.m
+++ b/UIViewController+TJLeakDetection.m
@@ -82,7 +82,9 @@ static NSHashTable *_tjvcld_trackedViewControllers;
     for (UIScene *scene in [[UIApplication sharedApplication] connectedScenes]) {
         if ([scene isKindOfClass:[UIWindowScene class]]) {
             for (UIWindow *window in [(UIWindowScene *)scene windows]) {
-                [rootViewControllers addObject:window.rootViewController];
+                if (window.rootViewController) {
+                    [rootViewControllers addObject:window.rootViewController];
+                }
             }
         }
     }


### PR DESCRIPTION
There are scenarios where `UIWindow` does not have a `rootViewController` assigned. The existence of a `rootViewController` should be check before attempting to insert it into the mutable `rootViewControllers` array.