### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ DerivedData/
 
 Carthage/Build/
 
+# Swift Package Manager
+
+.swiftpm
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "UIViewControllerLeakDetector",
+    platforms: [.iOS(.v13), .tvOS(.v13)],
+    products: [
+        .library(
+            name: "UIViewControllerLeakDetector",
+            targets: ["UIViewControllerLeakDetector"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "UIViewControllerLeakDetector",
+            path: ".",
+            sources: ["UIViewController+TJLeakDetection.m"],
+            publicHeadersPath: "."
+        )
+    ]
+)


### PR DESCRIPTION
This PR adds a Swift Package definition so Swift apps can integrate the code without needing to copy the Objective-C code and create a Swift bridging header. Swift Package manager takes care of generating the bridging header for the target.